### PR TITLE
Add Nix flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,6 @@ build and run `macfmt` directly from the provided flake:
 nix run github:bedecarroll/macfmt
 ```
 
-To add it as a dependency in your NixOS configuration, import the flake and use
-`packages.<system>.default`.
-
 ## Usage
 
 ### Basic Usage

--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ directly.
 cargo build --release
 ```
 
+### Using Nix
+
+If you have the [Nix](https://nixos.org/) package manager installed, you can
+build and run `macfmt` directly from the provided flake:
+
+```bash
+nix run github:bedecarroll/macfmt
+```
+
+To add it as a dependency in your NixOS configuration, import the flake and use
+`packages.<system>.default`.
+
 ## Usage
 
 ### Basic Usage

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "macfmt - format MAC addresses";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = "macfmt";
+          version = "0.1.0";
+          src = self;
+          cargoLock.lockFile = ./Cargo.lock;
+        };
+
+        apps.default = flake-utils.lib.mkApp {
+          drv = self.packages.${system}.default;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.rustc
+            pkgs.cargo
+            pkgs.clippy
+            pkgs.rustfmt
+          ];
+        };
+      });
+}


### PR DESCRIPTION
## Summary
- add a Nix flake to provide packages, app and devShell
- document how to use the flake in the installation section

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo build --release`
- `markdownlint-cli2 "**/*.md"`


------
https://chatgpt.com/codex/tasks/task_e_684a0cfe6020832aa789360959388f62