### PR TITLE
chore: update dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -54,7 +54,7 @@ jobs:
         run: cp target/${{ matrix.target }}/release/${{ matrix.binary_name }} ${{ matrix.archive_name }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.archive_name }}
           path: ${{ matrix.archive_name }}
@@ -67,10 +67,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
 
@@ -82,7 +82,7 @@ jobs:
           ls -la release/
 
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: release/*
           generate_release_notes: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -277,9 +277,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "macfmt"
@@ -353,9 +353,9 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ description = "A tool to format MAC addresses in various formats"
 authors = ["Bede Carroll"]
 
 [dependencies]
-clap = { version = "4.0", features = ["derive"] }
-regex = "1.5"
+clap = { version = "4.5", features = ["derive"] }
+regex = "1.12"
 log = "0.4"
 env_logger = "0.11"
 atty = "0.2"


### PR DESCRIPTION
Aggregate Dependabot updates:
- GitHub Actions: checkout@v5, download/upload-artifact v6/v5, softprops/action-gh-release v2
- Cargo crates: clap 4.5.51, regex 1.12.2, log 0.4.28

 and 
running 22 tests
test tests::test_edge_case_all_fs ... ok
test tests::test_edge_case_all_zeros ... ok
test tests::test_case_preservation ... ok
test tests::test_force_lowercase ... ok
test tests::test_force_uppercase ... ok
test tests::test_mac_address_parsing_bare_format ... ok
test tests::test_mac_address_parsing_case_preservation ... ok
test tests::test_mac_address_parsing_invalid_hex ... ok
test tests::test_mac_address_parsing_dot_format ... ok
test tests::test_mac_address_parsing_dash_format ... ok
test tests::test_mixed_separators_in_single_mac ... ok
test tests::test_mac_address_parsing_invalid_length ... ok
test tests::test_find_mac_addresses_no_matches ... ok
test tests::test_find_mac_addresses_multiple_formats ... ok
test tests::test_to_bare_format ... ok
test tests::test_mac_address_parsing_colon_format ... ok
test tests::test_to_standard_format ... ok
test tests::test_to_cisco_format ... ok
test tests::test_find_mac_addresses_mixed_case ... ok
test tests::test_to_windows_format ... ok
test tests::test_process_input_no_mac_addresses ... ok
test tests::test_regex_patterns ... ok

test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s run to refresh the lockfile and verify the binary.